### PR TITLE
Fix Sprite Blurriness

### DIFF
--- a/Project/Game1.cs
+++ b/Project/Game1.cs
@@ -81,7 +81,6 @@ namespace Project
 
             _spriteBatch.Begin(samplerState:SamplerState.PointClamp); // PointClamp fixes sprite blurriness
 
-
             blocks[CurrentBlockSpriteIndex].Draw(_spriteBatch, new Vector2(200, 100));
 
             _spriteBatch.End();


### PR DESCRIPTION
Fixes upscaled sprites from being blurry using SamplerState.PointClamp