### PR TITLE
Rename Parameters in Collision Handler

### DIFF
--- a/Project/Collision/CollisionHandlers/AllCollisionHandler.cs
+++ b/Project/Collision/CollisionHandlers/AllCollisionHandler.cs
@@ -16,7 +16,7 @@ using Project.Blocks;
 
 namespace Project.Collision
 {
-    class AllCollisionHandler
+    class AllCollisionHandler: ICollisionHandler
     {
         private Dictionary<Tuple<Type, Type>, ICollisionHandler> commandMap;
         public AllCollisionHandler()
@@ -62,13 +62,13 @@ namespace Project.Collision
         }
 
 
-        public void HandleCollision(ICollidable subject, ICollidable target, CollisionSide side)
+        public void HandleCollision(ICollidable collidee, ICollidable collider, CollisionSide side)
         {
-            Tuple<Type, Type> key = new Tuple<Type, Type>(subject.GetType(), target.GetType());
+            Tuple<Type, Type> key = new Tuple<Type, Type>(collidee.GetType(), collider.GetType());
             if (commandMap.ContainsKey(key))
             {
                 ICollisionHandler handler = commandMap[key];
-                handler.HandleCollision(subject, target, side);
+                handler.HandleCollision(collidee, collider, side);
             }
         }
     }

--- a/Project/Collision/CollisionHandlers/ICollisionHandler.cs
+++ b/Project/Collision/CollisionHandlers/ICollisionHandler.cs
@@ -6,6 +6,11 @@ namespace Project.Collision.CollisionHandlers
 {
     public interface ICollisionHandler
     {
-        public void HandleCollision(ICollidable subject, ICollidable target, CollisionSide side);
+        /* Interface for all collision handlers.
+         * Collidee is the object that the handler is operating upon.
+         * Collider is the object colliding with collidee.
+         * Side is the side of the collidee that the collider is colliding upon.
+         */
+        public void HandleCollision(ICollidable collidee, ICollidable collider, CollisionSide side);
     }
 }

--- a/Project/Collision/CollisionHandlers/PlayerBlockCollisionHandler.cs
+++ b/Project/Collision/CollisionHandlers/PlayerBlockCollisionHandler.cs
@@ -17,7 +17,7 @@ namespace Project.Collision.CollisionHandlers
             {
                 case CollisionSide.Up:
                     //Collided with top, move down
-                    dy = block.BoundingBox.Bottom -player.BoundingBox.Top;
+                    dy = block.BoundingBox.Bottom - player.BoundingBox.Top;
                     break;
                 case CollisionSide.Down:
                     //Collided with bottom, move up


### PR DESCRIPTION
Proposal for renaming parameters in collision handler to make it more clear what each parameter's role is. Actual handler implementations do NOT need to use there names, they can be descriptive of the object types the are intended to represent (such as block, player, etc.)
Also included description comment in ICollisionHandler