### PR TITLE
Add Enum For Locked Doors 

### DIFF
--- a/Project/Content/XML/Map_Building.xml
+++ b/Project/Content/XML/Map_Building.xml
@@ -187,6 +187,7 @@
 			<Object>
 				<ObjectType>Door</ObjectType>
 				<ObjectName>Closed</ObjectName>
+				<Enum>Block</Enum>
 				<Position>West</Position>
 			</Object>
 			<Object>
@@ -232,6 +233,7 @@
 			<Object>
 				<ObjectType>Door</ObjectType>
 				<ObjectName>Closed</ObjectName>
+				<Enum>Enemy</Enum>
 				<Position>East</Position>
 			</Object>
 			<Object>
@@ -1398,6 +1400,7 @@
 			<Object>
 				<ObjectType>Door</ObjectType>
 				<ObjectName>Closed</ObjectName>
+				<Enum>Enemy</Enum>
 				<Position>East</Position>
 			</Object>
 			<Object>


### PR DESCRIPTION
This is so we can distinguish doors that are opened via all enemies kill verses doors for where it requires a block to be moved.